### PR TITLE
DS-545 - [Swagger API] The upsert is not working for POST API

### DIFF
--- a/util/generateYaml.js
+++ b/util/generateYaml.js
@@ -420,12 +420,6 @@ function generateYaml(config) {
 				in: 'query',
 				description: 'Time after which the document will get deleted.',
 				schema: { type: 'string' }
-			},
-			{
-				name: 'upsert',
-				in: 'query',
-				description: 'upsert parameter',
-				schema: { type: 'boolean' }
 			}],
 			responses: {
 				'200': {

--- a/util/generateYamlSchemaFree.js
+++ b/util/generateYamlSchemaFree.js
@@ -233,12 +233,6 @@ function generateYaml(config) {
                 in: 'query',
                 description: 'Time after which the document will get deleted.',
                 schema: { type: 'string' }
-            },
-            {
-                name: 'upsert',
-                in: 'query',
-                description: 'upsert parameter',
-                schema: { type: 'boolean' }
             }],
             responses: {
                 '200': {


### PR DESCRIPTION
The `upsert` parameter is not required for `POST /` (swagger API). This commit removes `upsert` parameter.